### PR TITLE
REST API for addresses

### DIFF
--- a/address/api/fields.py
+++ b/address/api/fields.py
@@ -1,0 +1,22 @@
+from django.conf import settings
+from django.contrib.gis.geos import Point
+from rest_framework import serializers
+
+
+class LocationField(serializers.Field):
+    """
+    A serializer field that represents a location (a Point instance).
+    This uses the projection defined in settings.PROJECTION_SRID.
+    """
+
+    def to_internal_value(self, value: dict) -> Point:
+        return Point(
+            *value["coordinates"],
+            srid=settings.PROJECTION_SRID,
+        )
+
+    def to_representation(self, value) -> dict:
+        return {
+            "type": "point",
+            "coordinates": list(value.coords),
+        }

--- a/address/api/serializers.py
+++ b/address/api/serializers.py
@@ -1,0 +1,61 @@
+from parler_rest.fields import TranslatedFieldsField
+from parler_rest.serializers import TranslatableModelSerializer
+from rest_framework import serializers
+
+from ..models import Address, Municipality, Street
+from .fields import LocationField
+
+
+class TranslatedModelSerializer(TranslatableModelSerializer):
+    """
+    A serializer that formats translated strings under language codes, e.g.
+
+        {"fi": "Helsinki", "sv": "Helsingfors"}
+
+    The serializer inheriting this should have "translations" listed in its fields.
+    """
+
+    translations = TranslatedFieldsField()
+
+    def to_representation(self, obj):
+        representation = super().to_representation(obj)
+        translated_fields = {}
+        for lang_key, trans_dict in representation.pop("translations", {}).items():
+            for field_name, translation in trans_dict.items():
+                if field_name not in translated_fields:
+                    translated_fields[field_name] = {lang_key: translation}
+                else:
+                    translated_fields[field_name].update({lang_key: translation})
+        representation.update(translated_fields)
+        return representation
+
+
+class MunicipalitySerializer(TranslatedModelSerializer):
+    class Meta:
+        model = Municipality
+        fields = ["translations"]
+
+
+class StreetSerializer(TranslatedModelSerializer):
+    municipality = MunicipalitySerializer()
+
+    class Meta:
+        model = Street
+        fields = ["municipality", "translations"]
+
+
+class AddressSerializer(serializers.ModelSerializer):
+    street = StreetSerializer()
+    location = LocationField()
+
+    class Meta:
+        model = Address
+        fields = [
+            "street",
+            "number",
+            "number_end",
+            "letter",
+            "postal_code",
+            "location",
+            "modified_at",
+        ]

--- a/address/api/views.py
+++ b/address/api/views.py
@@ -1,3 +1,4 @@
+from django.db.models import Q, QuerySet
 from rest_framework.viewsets import ReadOnlyModelViewSet
 
 from ..models import Address
@@ -7,3 +8,49 @@ from .serializers import AddressSerializer
 class AddressViewSet(ReadOnlyModelViewSet):
     queryset = Address.objects.order_by("pk")
     serializer_class = AddressSerializer
+
+    def get_queryset(self) -> QuerySet:
+        addresses = self.queryset
+        addresses = self._filter_by_street_name(addresses)
+        addresses = self._filter_by_street_number(addresses)
+        addresses = self._filter_by_street_letter(addresses)
+        addresses = self._filter_by_municipality(addresses)
+        addresses = self._filter_by_postal_code(addresses)
+        # We have to do distinct here because filtering by the translated
+        # fields can return the same object multiple times if it has multiple
+        # translations (e.g. "fi" and "sv").
+        return addresses.distinct()
+
+    def _filter_by_street_name(self, addresses: QuerySet) -> QuerySet:
+        street_name = self.request.query_params.get("streetname")
+        if street_name is None:
+            return addresses
+        return addresses.filter(street__translations__name__iexact=street_name)
+
+    def _filter_by_street_number(self, addresses: QuerySet) -> QuerySet:
+        street_number = self.request.query_params.get("streetnumber")
+        if street_number is None:
+            return addresses
+        return addresses.filter(
+            Q(number__iexact=street_number) | Q(number_end__iexact=street_number)
+        )
+
+    def _filter_by_street_letter(self, addresses: QuerySet) -> QuerySet:
+        street_letter = self.request.query_params.get("streetletter")
+        if street_letter is None:
+            return addresses
+        return addresses.filter(letter__iexact=street_letter)
+
+    def _filter_by_municipality(self, addresses: QuerySet) -> QuerySet:
+        municipality = self.request.query_params.get("municipality")
+        if municipality is None:
+            return addresses
+        return addresses.filter(
+            street__municipality__translations__name__iexact=municipality
+        )
+
+    def _filter_by_postal_code(self, addresses: QuerySet) -> QuerySet:
+        postal_code = self.request.query_params.get("postalcode")
+        if postal_code is None:
+            return addresses
+        return addresses.filter(postal_code__iexact=postal_code)

--- a/address/api/views.py
+++ b/address/api/views.py
@@ -1,0 +1,9 @@
+from rest_framework.viewsets import ReadOnlyModelViewSet
+
+from ..models import Address
+from .serializers import AddressSerializer
+
+
+class AddressViewSet(ReadOnlyModelViewSet):
+    queryset = Address.objects.order_by("pk")
+    serializer_class = AddressSerializer

--- a/address/tests/factories.py
+++ b/address/tests/factories.py
@@ -1,4 +1,4 @@
-from factory import Faker, LazyAttribute, SubFactory
+from factory import Faker, LazyAttribute, post_generation, SubFactory
 from factory.django import DjangoModelFactory
 
 from ..models import Address, Municipality, Street
@@ -8,6 +8,12 @@ class MunicipalityFactory(DjangoModelFactory):
     id = LazyAttribute(lambda o: o.name.lower())
     name = Faker("city", locale="fi_FI")
 
+    @post_generation
+    def post(self, *_, **__):
+        name = self.name
+        self.set_current_language("sv")
+        self.name = name
+
     class Meta:
         model = Municipality
 
@@ -15,6 +21,12 @@ class MunicipalityFactory(DjangoModelFactory):
 class StreetFactory(DjangoModelFactory):
     municipality = SubFactory(MunicipalityFactory)
     name = Faker("street_name", locale="fi_FI")
+
+    @post_generation
+    def post(self, *_, **__):
+        name = self.name
+        self.set_current_language("sv")
+        self.name = name
 
     class Meta:
         model = Street

--- a/address/tests/test_api_fields.py
+++ b/address/tests/test_api_fields.py
@@ -1,0 +1,20 @@
+from django.conf import settings
+from django.contrib.gis.geos import Point
+
+from ..api.fields import LocationField
+
+
+def test_location_field_to_internal_value():
+    value = {"type": "point", "coordinates": [25.07142, 60.41270]}
+    expected = Point(*value["coordinates"], srid=settings.PROJECTION_SRID)
+    actual = LocationField(initial=expected).to_internal_value(value)
+    assert actual.coords == expected.coords
+    assert actual.srid == expected.srid
+
+
+def test_location_field_to_representation():
+    coords = [25.07081, 60.41292]
+    value = Point(*coords, srid=settings.PROJECTION_SRID)
+    expected = {"type": "point", "coordinates": coords}
+    actual = LocationField(initial=expected).to_representation(value)
+    assert actual == expected

--- a/address/tests/test_api_serializers.py
+++ b/address/tests/test_api_serializers.py
@@ -1,0 +1,72 @@
+from pytest import mark
+
+from ..api.serializers import (
+    AddressSerializer,
+    MunicipalitySerializer,
+    StreetSerializer,
+)
+from ..tests.factories import AddressFactory, MunicipalityFactory, StreetFactory
+
+
+@mark.django_db
+def test_municipality_serializer():
+    municipality = MunicipalityFactory()
+    serializer = MunicipalitySerializer()
+    actual = serializer.to_representation(municipality)
+    assert actual == {
+        "name": {
+            "fi": municipality.get_translation("fi", "translations").name,
+            "sv": municipality.get_translation("sv", "translations").name,
+        }
+    }
+
+
+@mark.django_db
+def test_street_serializer():
+    street = StreetFactory()
+    serializer = StreetSerializer()
+    actual = serializer.to_representation(street)
+    assert actual == {
+        "municipality": {
+            "name": {
+                "fi": street.municipality.get_translation("fi", "translations").name,
+                "sv": street.municipality.get_translation("sv", "translations").name,
+            }
+        },
+        "name": {
+            "fi": street.get_translation("fi", "translations").name,
+            "sv": street.get_translation("sv", "translations").name,
+        },
+    }
+
+
+@mark.django_db
+def test_address_serializer():
+    address = AddressFactory()
+    serializer = AddressSerializer()
+    actual = serializer.to_representation(address)
+    street = address.street
+    municipality = street.municipality
+    assert actual == {
+        "street": {
+            "municipality": {
+                "name": {
+                    "fi": municipality.get_translation("fi", "translations").name,
+                    "sv": municipality.get_translation("sv", "translations").name,
+                }
+            },
+            "name": {
+                "fi": street.get_translation("fi", "translations").name,
+                "sv": street.get_translation("sv", "translations").name,
+            },
+        },
+        "number": address.number,
+        "number_end": address.number_end,
+        "letter": address.letter,
+        "postal_code": address.postal_code,
+        "location": {
+            "type": "point",
+            "coordinates": [address.location.x, address.location.y],
+        },
+        "modified_at": address.modified_at.astimezone().isoformat(),
+    }

--- a/address/tests/test_api_views.py
+++ b/address/tests/test_api_views.py
@@ -3,7 +3,7 @@ from pytest import mark
 from rest_framework.test import APIClient
 
 from ..api.serializers import AddressSerializer
-from ..tests.factories import AddressFactory
+from ..tests.factories import AddressFactory, MunicipalityFactory, StreetFactory
 
 
 @mark.django_db
@@ -18,4 +18,102 @@ def test_get_address_list():
         "next": None,
         "previous": None,
         "results": [serializer.to_representation(address)],
+    }
+
+
+@mark.django_db
+def test_filter_addresses_by_street_name():
+    api_client = APIClient()
+    match = AddressFactory(street=StreetFactory(name="Matching Street"))
+    AddressFactory(street=StreetFactory(name="Other Street"))
+    serializer = AddressSerializer()
+    response = api_client.get(
+        reverse("address:address-list"), {"streetname": match.street.name}
+    )
+    assert response.status_code == 200
+    assert response.data == {
+        "count": 1,
+        "next": None,
+        "previous": None,
+        "results": [serializer.to_representation(match)],
+    }
+
+
+@mark.django_db
+def test_filter_addresses_by_street_number():
+    api_client = APIClient()
+    matching_number = 42
+    matches = [
+        AddressFactory(number=matching_number, number_end="99"),
+        AddressFactory(number="99", number_end=matching_number),
+    ]
+    AddressFactory(number="99", number_end="99")
+    AddressFactory(number="99", number_end="99")
+    serializer = AddressSerializer()
+    response = api_client.get(
+        reverse("address:address-list"), {"streetnumber": matching_number}
+    )
+    assert response.status_code == 200
+    assert response.data == {
+        "count": 2,
+        "next": None,
+        "previous": None,
+        "results": [serializer.to_representation(match) for match in matches],
+    }
+
+
+@mark.django_db
+def test_filter_addresses_by_street_letter():
+    api_client = APIClient()
+    matching_letter = "M"
+    match = AddressFactory(letter=matching_letter)
+    AddressFactory(letter="XX")
+    serializer = AddressSerializer()
+    response = api_client.get(
+        reverse("address:address-list"), {"streetletter": matching_letter}
+    )
+    assert response.status_code == 200
+    assert response.data == {
+        "count": 1,
+        "next": None,
+        "previous": None,
+        "results": [serializer.to_representation(match)],
+    }
+
+
+@mark.django_db
+def test_filter_addresses_by_municipality():
+    api_client = APIClient()
+    municipality = MunicipalityFactory(name="Match")
+    street = StreetFactory(municipality=municipality)
+    match = AddressFactory(street=street)
+    AddressFactory()
+    serializer = AddressSerializer()
+    response = api_client.get(
+        reverse("address:address-list"), {"municipality": municipality.name}
+    )
+    assert response.status_code == 200
+    assert response.data == {
+        "count": 1,
+        "next": None,
+        "previous": None,
+        "results": [serializer.to_representation(match)],
+    }
+
+
+@mark.django_db
+def test_filter_addresses_by_postal_code():
+    api_client = APIClient()
+    match = AddressFactory(postal_code="00100")
+    AddressFactory(postal_code="99999")
+    serializer = AddressSerializer()
+    response = api_client.get(
+        reverse("address:address-list"), {"postalcode": match.postal_code}
+    )
+    assert response.status_code == 200
+    assert response.data == {
+        "count": 1,
+        "next": None,
+        "previous": None,
+        "results": [serializer.to_representation(match)],
     }

--- a/address/tests/test_api_views.py
+++ b/address/tests/test_api_views.py
@@ -1,0 +1,21 @@
+from django.urls import reverse
+from pytest import mark
+from rest_framework.test import APIClient
+
+from ..api.serializers import AddressSerializer
+from ..tests.factories import AddressFactory
+
+
+@mark.django_db
+def test_get_address_list():
+    api_client = APIClient()
+    address = AddressFactory()
+    serializer = AddressSerializer()
+    response = api_client.get(reverse("address:address-list"))
+    assert response.status_code == 200
+    assert response.data == {
+        "count": 1,
+        "next": None,
+        "previous": None,
+        "results": [serializer.to_representation(address)],
+    }

--- a/address/urls.py
+++ b/address/urls.py
@@ -1,0 +1,11 @@
+from django.urls import include, path
+from rest_framework.routers import DefaultRouter
+
+from .api.views import AddressViewSet
+
+router = DefaultRouter()
+router.register(r"address", AddressViewSet)
+
+urlpatterns = [
+    path("", include(router.urls)),
+]

--- a/geo_search/settings.py
+++ b/geo_search/settings.py
@@ -92,3 +92,8 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 # SRID for the locations stored in the application database
 PROJECTION_SRID = 4326  # WGS84
+
+REST_FRAMEWORK = {
+    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+    "PAGE_SIZE": 20,
+}

--- a/geo_search/urls.py
+++ b/geo_search/urls.py
@@ -1,6 +1,9 @@
 from django.contrib import admin
-from django.urls import path
+from django.urls import include, path
+
+from address import urls as addresses_urls
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("v1/", include((addresses_urls, "address"), namespace="v1/address")),
 ]

--- a/requirements.in
+++ b/requirements.in
@@ -2,6 +2,7 @@ Django
 django-cors-headers
 django-environ
 django-parler
+django-parler-rest
 djangorestframework
 factory-boy
 psycopg2

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,9 +16,15 @@ django-cors-headers==3.8.0
 django-environ==0.6.0
     # via -r requirements.in
 django-parler==2.2
+    # via
+    #   -r requirements.in
+    #   django-parler-rest
+django-parler-rest==2.1
     # via -r requirements.in
 djangorestframework==3.12.4
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   django-parler-rest
 factory-boy==3.2.0
     # via -r requirements.in
 faker==8.12.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,11 @@ norecursedirs = node_modules .git venv*
 filterwarnings =
     # Ignore deprecation warning from django-parler until it has been fixed upstream
     ignore:The providing_args argument is deprecated:django.utils.deprecation.RemovedInDjango40Warning:parler
+    # Ignore deprecation warnings from django-parler-rest until they have been fixed upstream
+    ignore:django.utils.translation.ugettext_lazy\(\) is deprecated:django.utils.deprecation.RemovedInDjango40Warning:parler_rest
+    # Ignore whitenoise warning about static directory not existing during tests
+    ignore:No directory at:UserWarning:whitenoise.base
+
 
 [isort]
 known_first_party=geo_search


### PR DESCRIPTION
This PR exposes the addresses via a REST API.

It's a read-only API with an endpoint at `/v1/address/`.

The address serialization for the API is quite heavily based on https://api.hel.fi/servicemap/v2/address/.

### Listing all addresses

You can get all addresses with a `GET` request to `/v1/address/`. There is pagination with 20 addresses per page.

Example JSON:

```
{
    "count": 1415082,
    "next": "http://0.0.0.0:8081/v1/address/?page=2",
    "previous": null,
    "results": [
        {
            "street": {
                "municipality": {
                    "name": {
                        "sv": "Askola",
                        "fi": "Askola"
                    }
                },
                "name": {
                    "sv": "",
                    "fi": "Lippuleuantie"
                }
            },
            "number": "121",
            "number_end": "",
            "letter": "",
            "postal_code": null,
            "location": {
                "type": "point",
                "coordinates": [
                    25.67739498349791,
                    60.58881017214497
                ]
            },
            "modified_at": "2021-09-17T08:55:33.438283+03:00"
        },
        ...
    ]
}
```

### Filtering results

The addresses can be filtered with the query parameters `streetname`, `streetnumber`, `streetletter`, `municipality`, and `postalcode`.

For example a `GET` request to `/v1/address/?streetname=Mannerheimintie&steetnumber=2` gives you all addresses with that street name regardless of municipality or other fields. Filtering by number searches from both `number` and `number_end` fields on the `Address` model. Filtering is done case-insensitively.

Filtering by a translated field will match translations as well. For example, `streetname` can be either the Finnish or Swedish name (`Mannerheimintie` or `Mannerheimvägen`).