### PR TITLE
Filter by bounding box

### DIFF
--- a/address/tests/factories.py
+++ b/address/tests/factories.py
@@ -16,6 +16,7 @@ class MunicipalityFactory(DjangoModelFactory):
 
     class Meta:
         model = Municipality
+        django_get_or_create = ("id",)
 
 
 class StreetFactory(DjangoModelFactory):


### PR DESCRIPTION
This PR adds the ability to filter by a bounding box, e.g.:

```
/v1/address/?bbox=24.68279,60.52439,24.59114,60.54042
```

This limits the QuerySet to addresses whose location is within that bounding box.