### PR TITLE
Add ability to get responses in XML format

### DIFF
--- a/geo_search/settings.py
+++ b/geo_search/settings.py
@@ -94,6 +94,11 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 PROJECTION_SRID = 4326  # WGS84
 
 REST_FRAMEWORK = {
+    "DEFAULT_RENDERER_CLASSES": [
+        "rest_framework.renderers.JSONRenderer",
+        "rest_framework.renderers.BrowsableAPIRenderer",
+        "rest_framework_xml.renderers.XMLRenderer",
+    ],
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 20,
 }

--- a/requirements.in
+++ b/requirements.in
@@ -4,6 +4,7 @@ django-environ
 django-parler
 django-parler-rest
 djangorestframework
+djangorestframework-xml
 factory-boy
 psycopg2
 whitenoise

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,8 @@
 #
 asgiref==3.4.1
     # via django
+defusedxml==0.7.1
+    # via djangorestframework-xml
 django==3.2.7
     # via
     #   -r requirements.in
@@ -25,6 +27,8 @@ djangorestframework==3.12.4
     # via
     #   -r requirements.in
     #   django-parler-rest
+djangorestframework-xml==2.0.0
+    # via -r requirements.in
 factory-boy==3.2.0
     # via -r requirements.in
 faker==8.12.1


### PR DESCRIPTION
This PR adds the ability to get responses in XML format.

By default, the API returns JSON responses. If we browse the API with the browser, the browsable API will be shown instead. 

By adding `&format=xxx` to the URL, you can specify the format explicitly. So to get the addresses in XML format, you can `GET /v1/address/?format=xml`.