### PR TITLE
Add health check and readiness endpoints

### DIFF
--- a/geo_search/tests/test_endpoints.py
+++ b/geo_search/tests/test_endpoints.py
@@ -1,0 +1,12 @@
+from pytest import mark
+
+
+def test_healthz_endpoint(client):
+    response = client.get("/healthz")
+    assert response.status_code == 200
+
+
+@mark.django_db
+def test_readiness_endpoint(client):
+    response = client.get("/readiness")
+    assert response.status_code == 200

--- a/geo_search/urls.py
+++ b/geo_search/urls.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.http import HttpResponse
 from django.urls import include, path
 
 from address import urls as addresses_urls
@@ -7,3 +8,28 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("v1/", include((addresses_urls, "address"), namespace="v1/address")),
 ]
+
+
+def healthz(*args, **kwargs) -> HttpResponse:
+    """Returns status code 200 if the server is alive."""
+    return HttpResponse(status=200)
+
+
+def readiness(*args, **kwargs) -> HttpResponse:
+    """
+    Returns status code 200 if the server is ready to perform its duties.
+
+    This goes through each database connection and perform a standard SQL
+    query without requiring any particular tables to exist.
+    """
+    from django.db import connections
+
+    for name in connections:
+        cursor = connections[name].cursor()
+        cursor.execute("SELECT 1;")
+        cursor.fetchone()
+
+    return HttpResponse(status=200)
+
+
+urlpatterns += [path("healthz", healthz), path("readiness", readiness)]

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -9,3 +9,6 @@ buffer-size = 32768
 master = 1
 processes = 4
 threads = 1
+; don't log readiness and healthz endpoints
+route = ^/readiness$ donotlog:
+route = ^/healthz$ donotlog:


### PR DESCRIPTION
This adds `/healthz` and `/readiness` endpoints to the URLs.

* `/healthz` returns `200 OK` when the service is alive
* `/readiness` returns `200 OK` when the service is ready to start accepting traffic

These endpoints follow the same naming and practice as other City of Helsinki projects. The only difference is that the `/readiness` endpoint also checks that the database is available. It does so by getting a cursor and running a `SELECT 1;` query.