### PR TITLE
Fix Python 3.8 incompatibilities and missing 'unzip'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:20.04
 WORKDIR /app
 
 RUN apt-get update && \
-    TZ="Europe/Helsinki" DEBIAN_FRONTEND=noninteractive apt-get install -y python3-pip gdal-bin uwsgi uwsgi-plugin-python3 libgdal26 postgresql-client netcat gettext git-core libpq-dev && \
+    TZ="Europe/Helsinki" DEBIAN_FRONTEND=noninteractive apt-get install -y python3-pip gdal-bin uwsgi uwsgi-plugin-python3 libgdal26 postgresql-client netcat gettext git-core libpq-dev unzip && \
     ln -s /usr/bin/pip3 /usr/local/bin/pip && \
     ln -s /usr/bin/python3 /usr/local/bin/python
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The project is now running at [localhost:8081](http://localhost:8081)
 Prerequisites:
 
 * PostgreSQL 11 or higher with PostGIS extension
-* Python 3.9
+* Python 3.8 or higher
 
 ### Installing Python requirements
 

--- a/address/services/address_import.py
+++ b/address/services/address_import.py
@@ -2,7 +2,7 @@ from bisect import bisect_left
 from django.conf import settings
 from django.contrib.gis.gdal.feature import Feature
 from django.contrib.gis.geos import LineString, MultiPoint, Point
-from functools import cache
+from functools import lru_cache
 from math import sqrt
 from typing import Dict, Iterable, List
 
@@ -222,7 +222,7 @@ def _find_normal(
     return x, y
 
 
-@cache
+@lru_cache(maxsize=None)
 def _create_municipality(municipality_id: int) -> Municipality:
     """Create a new municipality if it does not exist already, and return it."""
     municipality_fi, municipality_sv = MUNICIPALITIES[municipality_id]
@@ -235,7 +235,7 @@ def _create_municipality(municipality_id: int) -> Municipality:
     return municipality
 
 
-@cache
+@lru_cache(maxsize=None)
 def _create_street(name_fi: str, name_sv: str, municipality: Municipality) -> Street:
     """Create a new street if it does not exist already, and return it."""
     street, _ = Street.objects.translated(name=name_fi).get_or_create(

--- a/address/services/address_import.py
+++ b/address/services/address_import.py
@@ -4,7 +4,7 @@ from django.contrib.gis.gdal.feature import Feature
 from django.contrib.gis.geos import LineString, MultiPoint, Point
 from functools import lru_cache
 from math import sqrt
-from typing import Dict, Iterable, List
+from typing import Dict, Iterable, List, Tuple
 
 from address.models import Address, Municipality, Street
 
@@ -116,7 +116,7 @@ def _build_addresses_from_feature(feature: Feature) -> List[Address]:
 def _build_addresses_on_side(
     street: Street,
     feature: Feature,
-    normals: Dict[float, tuple[float, float]],
+    normals: Dict[float, Tuple[float, float]],
     right_side: bool,
 ) -> List[Address]:
     """Constructs addresses for one side (right or left) of a street."""
@@ -179,7 +179,7 @@ def _find_numbers(feature: Feature, right_side: bool = False) -> range:
     return range(first_number, last_number + last_number_offset, number_increment)
 
 
-def _compute_normals(line_string: LineString) -> Dict[float, tuple[float, float]]:
+def _compute_normals(line_string: LineString) -> Dict[float, Tuple[float, float]]:
     """
     Compute a lookup table for the normals for each line segment in the line string.
     This is done so that given an interpolated distance (between 0 and 1) on the line
@@ -206,7 +206,7 @@ def _compute_normals(line_string: LineString) -> Dict[float, tuple[float, float]
 
 def _find_normal(
     distance: float, normals: dict, opposite: bool = False
-) -> tuple[float, float]:
+) -> Tuple[float, float]:
     """
     Given an distance between 0 and 1 on the line string, find the normal
     (or its opposite) from the provided dictionary.


### PR DESCRIPTION
I tried running the address import scripts inside the Docker image, and noticed a couple of embarrassing problems:

* Ubuntu 20.04 does not actually ship with Python 3.9 🤦‍♂️
* `unzip` must be installed separately

In this PR, I have fixed the `Dockerfile` to install `unzip`.

I have also fixed the `address_import` management command to avoid any Python 3.9 specific features. After these changes, the service is fully compatible with both Python 3.8 and Python 3.9.