### PR TITLE
Read .env file only if it exists

### DIFF
--- a/geo_search/settings.py
+++ b/geo_search/settings.py
@@ -16,7 +16,9 @@ env = Env(
     ),
 )
 
-Env.read_env(BASE_DIR / ".env")
+env_path = BASE_DIR / ".env"
+if env_path.exists():
+    Env.read_env(env_path)
 
 DEBUG = env.bool("DEBUG")
 SECRET_KEY = env.str("SECRET_KEY")


### PR DESCRIPTION
Modified the settings so that the `.env` file is not read if it doesn't exist. This makes it more compatible with running in OpenShift where we don't use `.env` files.