### PR TITLE
Add ability to filter by post office

### DIFF
--- a/address/api/views.py
+++ b/address/api/views.py
@@ -21,6 +21,7 @@ class AddressViewSet(ReadOnlyModelViewSet):
         addresses = self._filter_by_street_letter(addresses)
         addresses = self._filter_by_municipality(addresses)
         addresses = self._filter_by_postal_code(addresses)
+        addresses = self._filter_by_post_office(addresses)
         addresses = self._filter_by_bbox(addresses)
         addresses = self._filter_by_location(addresses)
         return addresses
@@ -60,6 +61,12 @@ class AddressViewSet(ReadOnlyModelViewSet):
         if postal_code is None:
             return addresses
         return addresses.filter(postal_code__iexact=postal_code)
+
+    def _filter_by_post_office(self, addresses: QuerySet) -> QuerySet:
+        post_office = self.request.query_params.get("postoffice")
+        if post_office is None:
+            return addresses
+        return addresses.filter(post_office__iexact=post_office)
 
     def _filter_by_bbox(self, addresses: QuerySet) -> QuerySet:
         bbox = self.request.query_params.get("bbox")

--- a/address/tests/test_api_views.py
+++ b/address/tests/test_api_views.py
@@ -122,6 +122,24 @@ def test_filter_addresses_by_postal_code():
 
 
 @mark.django_db
+def test_filter_addresses_by_post_office():
+    api_client = APIClient()
+    match = AddressFactory(post_office="Askola")
+    AddressFactory(post_office="Helsinki")
+    serializer = AddressSerializer()
+    response = api_client.get(
+        reverse("address:address-list"), {"postoffice": match.post_office}
+    )
+    assert response.status_code == 200
+    assert response.data == {
+        "count": 1,
+        "next": None,
+        "previous": None,
+        "results": [serializer.to_representation(match)],
+    }
+
+
+@mark.django_db
 def test_filter_addresses_by_bbox():
     api_client = APIClient()
     match = AddressFactory(


### PR DESCRIPTION
This PR adds the `postoffice` query parameter to the address API.

For example, `/v1/address/?postoffice=Askola` will return all addresses with that post office.