### PR TITLE
Configure Sentry

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -8,4 +8,5 @@ djangorestframework-xml
 drf-spectacular
 factory-boy
 psycopg2
+sentry-sdk
 whitenoise

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,8 @@ asgiref==3.4.1
     # via django
 attrs==21.2.0
     # via jsonschema
+certifi==2021.10.8
+    # via sentry-sdk
 defusedxml==0.7.1
     # via djangorestframework-xml
 django==3.2.7
@@ -53,6 +55,8 @@ pytz==2021.1
     # via django
 pyyaml==5.4.1
     # via drf-spectacular
+sentry-sdk==1.4.3
+    # via -r requirements.in
 six==1.16.0
     # via python-dateutil
 sqlparse==0.4.1
@@ -61,5 +65,7 @@ text-unidecode==1.3
     # via faker
 uritemplate==4.0.0
     # via drf-spectacular
+urllib3==1.26.7
+    # via sentry-sdk
 whitenoise==5.3.0
     # via -r requirements.in


### PR DESCRIPTION
This PR adds Sentry configuration to the project.

To enable Sentry, a new project for `geo-search` should be created in Sentry on City of Helsinki account, and the environment variables should be configured in Azure DevOps:

* `SENTRY_DSN` should be the client key copied from the Sentry web interface for the geo-search project
* `SENTRY_ENVIRONMENT` should be one of the environments defined for the Sentry project (usually `development`, `testing`, `staging`, or `production`).