### PR TITLE
Fix tests failing without authorization requirement

### DIFF
--- a/geo_search/tests/conftest.py
+++ b/geo_search/tests/conftest.py
@@ -2,5 +2,10 @@ from pytest import fixture
 
 
 @fixture
+def authorization_required(settings):
+    settings.REQUIRE_AUTHORIZATION = True
+
+
+@fixture
 def no_authorization_required(settings):
     settings.REQUIRE_AUTHORIZATION = False

--- a/geo_search/tests/test_permissions.py
+++ b/geo_search/tests/test_permissions.py
@@ -4,21 +4,22 @@ from rest_framework.test import APIClient
 from rest_framework_api_key.models import APIKey
 
 
+@mark.usefixtures("authorization_required")
 def test_anonymous_client_cannot_access_api_without_api_key():
     api_client = APIClient()
     response = api_client.get("/v1/")
     assert response.status_code == 403
 
 
-def test_anonymous_client_can_access_api_if_authorization_is_not_required(
-    no_authorization_required,
-):
+@mark.usefixtures("no_authorization_required")
+def test_anonymous_client_can_access_api_if_authorization_is_not_required():
     api_client = APIClient()
     response = api_client.get("/v1/")
     assert response.status_code == 200
 
 
 @mark.django_db
+@mark.usefixtures("authorization_required")
 def test_anonymous_client_can_access_api_with_valid_api_key():
     valid_api_key = APIKey.objects.create_key(name="test")[-1]
     api_client = APIClient(HTTP_AUTHORIZATION=f"Api-Key {valid_api_key}")
@@ -27,6 +28,7 @@ def test_anonymous_client_can_access_api_with_valid_api_key():
 
 
 @mark.django_db
+@mark.usefixtures("authorization_required")
 def test_anonymous_client_cannot_access_api_with_revoked_api_key():
     revoked_api_key = APIKey.objects.create_key(name="test", revoked=True)[-1]
     api_client = APIClient(HTTP_AUTHORIZATION=f"Api-Key {revoked_api_key}")
@@ -35,6 +37,7 @@ def test_anonymous_client_cannot_access_api_with_revoked_api_key():
 
 
 @mark.django_db
+@mark.usefixtures("authorization_required")
 def test_authenticated_client_can_access_api():
     user = User.objects.create()
     api_client = APIClient()


### PR DESCRIPTION
This PR fixes permission tests that assume `REQUIRE_AUTHORIZATION` is `True`.

The tests now set the setting variable using a fixture, so the value in `.env` (or environment variable) shouldn't matter.