### PR TITLE
Feature/import addresses for province of southwest finland

### DIFF
--- a/address/management/commands/import_addresses.py
+++ b/address/management/commands/import_addresses.py
@@ -21,7 +21,7 @@ from django.core.management.base import BaseCommand
 from pathlib import Path
 from time import time
 
-from ...services.address_import import delete_address_data, import_addresses
+from ...services.address_import import AddressImporter
 
 
 class Command(BaseCommand):
@@ -29,17 +29,19 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser) -> None:
         parser.add_argument("files", nargs="+", type=Path)
+        parser.add_argument("province")
 
     def handle(self, *args, **options) -> None:
         start_time = time()
-        self.stdout.write("Deleting existing data.")
-        delete_address_data()
+        self.stdout.write(f"Deleting existing data for province {options['province']}.")
+        importer = AddressImporter(options["province"])
+        importer.delete_address_data()
         paths = options["files"]
         total_addresses = 0
         for path in paths:
             self.stdout.write(f"Reading data from {path}.")
             for layer in DataSource(path):
-                num_addresses = import_addresses(layer)
+                num_addresses = importer.import_addresses(layer)
                 total_addresses += num_addresses
                 self.stdout.write(f"{num_addresses} addresses imported from {path}.")
         self.stdout.write(

--- a/address/management/commands/import_postal_codes.py
+++ b/address/management/commands/import_postal_codes.py
@@ -8,7 +8,7 @@ from django.core.management.base import BaseCommand
 from pathlib import Path
 from time import time
 
-from ...services.postal_code_import import import_postal_codes
+from ...services.postal_code_import import PostalCodeImporter
 
 
 class Command(BaseCommand):
@@ -19,12 +19,13 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options) -> None:
         start_time = time()
+        importer = PostalCodeImporter()
         paths = options["files"]
         num_addresses_updated = 0
         for path in paths:
             self.stdout.write(f"Reading data from {path}.")
             for layer in DataSource(path, encoding="latin-1"):
-                num_addresses_updated += import_postal_codes(layer)
+                num_addresses_updated += importer.import_postal_codes(layer)
         self.stdout.write(
             self.style.SUCCESS(
                 f"{num_addresses_updated} addresses updated "

--- a/address/services/address_import.py
+++ b/address/services/address_import.py
@@ -21,238 +21,287 @@ ADDRESS_BATCH_SIZE = 1000
 # The municipality names are not included in the Digiroad data, so this table is used to
 # map each municipality number to the Finnish and Swedish names.
 MUNICIPALITIES = {
-    18: ("Askola", "Askola"),
-    49: ("Espoo", "Esbo"),
-    78: ("Hanko", "Hangö"),
-    91: ("Helsinki", "Helsingfors"),
-    92: ("Vantaa", "Vanda"),
-    106: ("Hyvinkää", "Hyvinge"),
-    149: ("Inkoo", "Ingå"),
-    186: ("Järvenpää", "Träskända"),
-    224: ("Karkkila", "Högfors"),
-    235: ("Kauniainen", "Grankulla"),
-    245: ("Kerava", "Kervo"),
-    257: ("Kirkkonummi", "Kyrkslätt"),
-    407: ("Lapinjärvi", "Lappträsk"),
-    434: ("Loviisa", "Lovisa"),
-    444: ("Lohja", "Lojo"),
-    504: ("Myrskylä", "Mörskom"),
-    505: ("Mäntsälä", "Mäntsälä"),
-    543: ("Nurmijärvi", "Nurmijärvi"),
-    611: ("Pornainen", "Borgnäs"),
-    616: ("Pukkila", "Pukkila"),
-    638: ("Porvoo", "Borgå"),
-    710: ("Raasepori", "Raseborg"),
-    753: ("Sipoo", "Sibbo"),
-    755: ("Siuntio", "Sjundeå"),
-    858: ("Tuusula", "Tusby"),
-    927: ("Vihti", "Vichtis"),
+    "uusimaa": {
+        18: ("Askola", "Askola"),
+        49: ("Espoo", "Esbo"),
+        78: ("Hanko", "Hangö"),
+        91: ("Helsinki", "Helsingfors"),
+        92: ("Vantaa", "Vanda"),
+        106: ("Hyvinkää", "Hyvinge"),
+        149: ("Inkoo", "Ingå"),
+        186: ("Järvenpää", "Träskända"),
+        224: ("Karkkila", "Högfors"),
+        235: ("Kauniainen", "Grankulla"),
+        245: ("Kerava", "Kervo"),
+        257: ("Kirkkonummi", "Kyrkslätt"),
+        407: ("Lapinjärvi", "Lappträsk"),
+        434: ("Loviisa", "Lovisa"),
+        444: ("Lohja", "Lojo"),
+        504: ("Myrskylä", "Mörskom"),
+        505: ("Mäntsälä", "Mäntsälä"),
+        543: ("Nurmijärvi", "Nurmijärvi"),
+        611: ("Pornainen", "Borgnäs"),
+        616: ("Pukkila", "Pukkila"),
+        638: ("Porvoo", "Borgå"),
+        710: ("Raasepori", "Raseborg"),
+        753: ("Sipoo", "Sibbo"),
+        755: ("Siuntio", "Sjundeå"),
+        858: ("Tuusula", "Tusby"),
+        927: ("Vihti", "Vichtis"),
+    },
+    "varsinais-suomi": {
+        19: ("Aura", "Aura"),
+        202: ("Kaarina", "S:t Karins"),
+        322: ("Kemiö", "Kimito"),
+        284: ("Koski Tl", "Koskis"),
+        304: ("Kustaavi", "Gustavs"),
+        400: ("Laitila", "Letala"),
+        423: ("Lieto", "Lundo"),
+        430: ("Loimaa", "Loimaa"),
+        445: ("Parainen", "Pargas"),
+        480: ("Marttila", "S:t Mårtens"),
+        481: ("Masku", "Masko"),
+        503: ("Mynämäki", "Virmo"),
+        529: ("Naantali", "Nådendal"),
+        538: ("Nousiainen", "Nousis"),
+        561: ("Oripää", "Oripää"),
+        573: ("Parainen", "Pargas"),
+        577: ("Paimio", "Pemar"),
+        631: ("Pyhäranta", "Pyhäranta"),
+        636: ("Pöytyä", "Pöytis"),
+        680: ("Raisio", "Reso"),
+        704: ("Rusko", "Rusko"),
+        734: ("Salo", "Salo"),
+        738: ("Sauvo", "Sagu"),
+        761: ("Somero", "Somero"),
+        833: ("Taivassalo", "Tövsala"),
+        853: ("Turku", "Åbo"),
+        895: ("Uusikaupunki", "Nystad"),
+        918: ("Vehmaa", "Vemo"),
+    },
 }
 
 
-def delete_address_data() -> None:
-    """Delete the existing address-related data."""
-    Municipality.objects.all().delete()
-    Street.objects.all().delete()
-    Address.objects.all().delete()
+class AddressImporter:
+    def __init__(self, province: str = None):
+        self.province = province
 
-
-def import_addresses(features: Iterable[Feature]) -> int:
-    """Create addresses from the given features."""
-    addresses = []
-    num_addresses = 0
-    for i, feature in enumerate(features, start=1):
-        feature_addresses = _build_addresses_from_feature(feature)
-        num_addresses += len(feature_addresses)
-        addresses.extend(feature_addresses)
-        if len(addresses) > ADDRESS_BATCH_SIZE:
-            _transform_address_locations(addresses)
-            Address.objects.bulk_create(addresses)
-            addresses.clear()
-    _transform_address_locations(addresses)
-    Address.objects.bulk_create(addresses)
-    return num_addresses
-
-
-def _transform_address_locations(addresses: List[Address]) -> None:
-    """
-    Transforms the locations of each given address to the projection given in settings.
-    The points are transformed in bulk through a MultiPoint because it's significantly
-    faster than transforming each point individually.
-    """
-    if not addresses:
-        return
-    locations = [address.location for address in addresses]
-    srid = locations[0].srid  # Each location has the same SRID
-    transformed_points = MultiPoint(locations, srid=srid)
-    transformed_points.transform(settings.PROJECTION_SRID)
-    for i, address in enumerate(addresses):
-        address.location = transformed_points[i]
-
-
-def _build_addresses_from_feature(feature: Feature) -> List[Address]:
-    """Construct addresses from the given feature."""
-    if not _has_required_fields(feature):
-        return []
-
-    # Create the street and municipality if they don't exist yet
-    street = _create_street(
-        feature["TIENIMI_SU"].value or "",
-        feature["TIENIMI_RU"].value or "",
-        _create_municipality(feature["KUNTAKOODI"].value),
-    )
-
-    # Calculate a lookup table for the normals to avoid computing
-    # them multiple times for the same geometry.
-    normals = _compute_normals(feature.geom.geos)
-
-    # Construct addresses for each side of the street. They have to be done
-    # separately since each side may have a different number of addresses.
-    addresses = _build_addresses_on_side(street, feature, normals, right_side=True)
-    addresses += _build_addresses_on_side(street, feature, normals, right_side=False)
-    return addresses
-
-
-def _build_addresses_on_side(
-    street: Street,
-    feature: Feature,
-    normals: Dict[float, Tuple[float, float]],
-    right_side: bool,
-) -> List[Address]:
-    """Constructs addresses for one side (right or left) of a street."""
-    numbers = _find_numbers(feature, right_side)
-    if not numbers:
-        return []  # No buildings on this side of the street
-
-    # The street numbers are spread evenly to the length of the street link. This means
-    # that if there is only one number, the address location will be in the middle
-    # (normalized distance 0.5) of the line segment. If there are two numbers, they
-    # will be at distance 0.25 and 0.75, and so on.
-    interval = 1.0 / len(numbers)
-    start_distance = interval / 2
-
-    line_string = feature.geom.geos
-    addresses = []
-    for i, number in enumerate(numbers):
-        # Distance between 0 and 1 on the line string where the address should be placed
-        distance = start_distance + i * interval
-
-        # To be able to translate the location towards the side of the street,
-        # we need to find the normal of the street at the given distance.
-        normal_x, normal_y = _find_normal(distance, normals, right_side)
-
-        # Now we can find the exact point on the line string at the given distance,
-        # and translate it along the normal.
-        street_location = line_string.interpolate_normalized(distance)
-        location = Point(
-            x=street_location.x + normal_x * ADDRESS_LOCATION_OFFSET_METERS,
-            y=street_location.y + normal_y * ADDRESS_LOCATION_OFFSET_METERS,
-            srid=street_location.srid,
-        )
-        addresses.append(Address(street=street, number=number, location=location))
-
-    return addresses
-
-
-def _find_numbers(feature: Feature, right_side: bool = False) -> range:
-    """Find the numbers on the given side of the street from the feature."""
-    # Get first and last building numbers on this side of the street from the feature
-    if right_side:
-        first_number = feature["ENS_TALO_O"].value
-        last_number = feature["VIIM_TAL_O"].value
-    else:
-        first_number = feature["ENS_TALO_V"].value
-        last_number = feature["VIIM_TAL_V"].value
-
-    if first_number is None or last_number is None:
-        return range(0)  # This side of the street has no buildings
-
-    # Depending on the digitizing direction, for some street links
-    # the last and first number might be in the opposite order.
-    if last_number < first_number:
-        number_increment = -2
-        last_number_offset = -1
-    else:
-        number_increment = 2
-        last_number_offset = 1
-
-    return range(first_number, last_number + last_number_offset, number_increment)
-
-
-def _compute_normals(line_string: LineString) -> Dict[float, Tuple[float, float]]:
-    """
-    Compute a lookup table for the normals for each line segment in the line string.
-    This is done so that given an interpolated distance (between 0 and 1) on the line
-    string, we can quickly find the normal at that distance.
-    """
-    normals = {}
-    start_x, start_y = line_string[0][:2]
-    for end_x, end_y, *_ in line_string[1:]:
-        if (end_x, end_y) == line_string[-1][:2]:
-            distance = 1  # Make sure distance 1 ends at the last point
+    def delete_address_data(self) -> None:
+        """Delete the existing address-related data."""
+        if self.province in MUNICIPALITIES.keys():
+            muni_ids = [
+                muni[1][0].lower() for muni in MUNICIPALITIES[self.province].items()
+            ]
+            streets = Street.objects.filter(municipality_id__in=muni_ids)
+            Municipality.objects.filter(id__in=muni_ids).delete()
+            Street.objects.filter(municipality_id__in=muni_ids).delete()
+            Address.objects.filter(street_id__in=streets.values_list("id")).delete()
         else:
-            distance = line_string.project_normalized(Point(end_x, end_y))
-        # Calculate the normal
-        dx = end_x - start_x
-        dy = end_y - start_y
-        length = sqrt(dx ** 2 + dy ** 2)
-        normal = -dy / length, dx / length
-        # Associate with the distance for fast lookup of the
-        # normal between the current start point and end point.
-        normals[distance] = normal
-        start_x, start_y = end_x, end_y
-    return normals
+            Municipality.objects.all().delete()
+            Street.objects.all().delete()
+            Address.objects.all().delete()
 
+    def import_addresses(self, features: Iterable[Feature]) -> int:
+        """Create addresses from the given features."""
+        addresses = []
+        num_addresses = 0
+        for i, feature in enumerate(features, start=1):
+            feature_addresses = self._build_addresses_from_feature(feature)
+            num_addresses += len(feature_addresses)
+            addresses.extend(feature_addresses)
+            if len(addresses) > ADDRESS_BATCH_SIZE:
+                self._transform_address_locations(addresses)
+                Address.objects.bulk_create(addresses)
+                addresses.clear()
 
-def _find_normal(
-    distance: float, normals: dict, opposite: bool = False
-) -> Tuple[float, float]:
-    """
-    Given an distance between 0 and 1 on the line string, find the normal
-    (or its opposite) from the provided dictionary.
-    """
-    distances = list(normals.keys())
-    distance_index = bisect_left(distances, distance)
-    normal_index = distances[distance_index]
-    x, y = normals[normal_index]
-    # If we are creating addresses for the right side of the street,
-    # we need the normal pointing in the opposite direction.
-    if opposite:
-        return -x, -y
-    return x, y
+        self._transform_address_locations(addresses)
+        Address.objects.bulk_create(addresses)
+        return num_addresses
 
+    def _transform_address_locations(self, addresses: List[Address]) -> None:
+        """
+        Transforms the locations of each given address to the projection given in
+        settings.The points are transformed in bulk through a MultiPoint because
+        it's significantly faster than transforming each point individually.
+        """
+        if not addresses:
+            return
+        locations = [address.location for address in addresses]
+        srid = locations[0].srid  # Each location has the same SRID
+        transformed_points = MultiPoint(locations, srid=srid)
+        transformed_points.transform(settings.PROJECTION_SRID)
+        for i, address in enumerate(addresses):
+            address.location = transformed_points[i]
 
-@lru_cache(maxsize=None)
-def _create_municipality(municipality_id: int) -> Municipality:
-    """Create a new municipality if it does not exist already, and return it."""
-    municipality_fi, municipality_sv = MUNICIPALITIES[municipality_id]
-    municipality, _ = Municipality.objects.get_or_create(id=municipality_fi.lower())
-    municipality.set_current_language("sv")
-    municipality.name = municipality_sv
-    municipality.set_current_language("fi")
-    municipality.name = municipality_fi
-    municipality.save()
-    return municipality
+    def _build_addresses_from_feature(self, feature: Feature) -> List[Address]:
+        """Construct addresses from the given feature."""
+        if not self._has_required_fields(feature):
+            return []
 
+        # Create the street and municipality if they don't exist yet
+        street = self._create_street(
+            feature["TIENIMI_SU"].value or "",
+            feature["TIENIMI_RU"].value or "",
+            self._create_municipality(feature["KUNTAKOODI"].value),
+        )
 
-@lru_cache(maxsize=None)
-def _create_street(name_fi: str, name_sv: str, municipality: Municipality) -> Street:
-    """Create a new street if it does not exist already, and return it."""
-    street, _ = Street.objects.translated(name=name_fi).get_or_create(
-        municipality=municipality
-    )
-    street.set_current_language("sv")
-    street.name = name_sv
-    street.set_current_language("fi")
-    street.name = name_fi
-    street.save()
-    return street
+        # Calculate a lookup table for the normals to avoid computing
+        # them multiple times for the same geometry.
+        normals = self._compute_normals(feature.geom.geos)
 
+        # Construct addresses for each side of the street. They have to be done
+        # separately since each side may have a different number of addresses.
+        addresses = self._build_addresses_on_side(
+            street, feature, normals, right_side=True
+        )
+        addresses += self._build_addresses_on_side(
+            street, feature, normals, right_side=False
+        )
+        return addresses
 
-def _has_required_fields(feature: Feature) -> bool:
-    """Check whether the feature contains street name and first/last numbers."""
-    street_keys = ["TIENIMI_SU", "TIENIMI_RU"]
-    number_keys = ["ENS_TALO_O", "ENS_TALO_V", "VIIM_TAL_O", "VIIM_TAL_V"]
-    has_street = any(feature[key].value for key in street_keys)
-    has_number = any(feature[key].value for key in number_keys)
-    return has_street and has_number
+    def _build_addresses_on_side(
+        self,
+        street: Street,
+        feature: Feature,
+        normals: Dict[float, Tuple[float, float]],
+        right_side: bool,
+    ) -> List[Address]:
+        """Constructs addresses for one side (right or left) of a street."""
+        numbers = self._find_numbers(feature, right_side)
+        if not numbers:
+            return []  # No buildings on this side of the street
+
+        # The street numbers are spread evenly to the length of the street link. This
+        # means that if there is only one number, the address location will be in the
+        # middle (normalized distance 0.5) of the line segment. If there are two
+        # numbers, they will be at distance 0.25 and 0.75, and so on.
+        interval = 1.0 / len(numbers)
+        start_distance = interval / 2
+
+        line_string = feature.geom.geos
+        addresses = []
+        for i, number in enumerate(numbers):
+            # Distance between 0 and 1 on the line string where the address should
+            # be placed
+            distance = start_distance + i * interval
+
+            # To be able to translate the location towards the side of the street,
+            # we need to find the normal of the street at the given distance.
+            normal_x, normal_y = self._find_normal(distance, normals, right_side)
+
+            # Now we can find the exact point on the line string at the given distance,
+            # and translate it along the normal.
+            street_location = line_string.interpolate_normalized(distance)
+            location = Point(
+                x=street_location.x + normal_x * ADDRESS_LOCATION_OFFSET_METERS,
+                y=street_location.y + normal_y * ADDRESS_LOCATION_OFFSET_METERS,
+                srid=street_location.srid,
+            )
+            addresses.append(Address(street=street, number=number, location=location))
+
+        return addresses
+
+    def _find_numbers(self, feature: Feature, right_side: bool = False) -> range:
+        """Find the numbers on the given side of the street from the feature."""
+        # Get first and last building numbers on this side of the street from the
+        # feature
+        if right_side:
+            first_number = feature["ENS_TALO_O"].value
+            last_number = feature["VIIM_TAL_O"].value
+        else:
+            first_number = feature["ENS_TALO_V"].value
+            last_number = feature["VIIM_TAL_V"].value
+
+        if first_number is None or last_number is None:
+            return range(0)  # This side of the street has no buildings
+
+        # Depending on the digitizing direction, for some street links
+        # the last and first number might be in the opposite order.
+        if last_number < first_number:
+            number_increment = -2
+            last_number_offset = -1
+        else:
+            number_increment = 2
+            last_number_offset = 1
+
+        return range(first_number, last_number + last_number_offset, number_increment)
+
+    def _compute_normals(
+        self, line_string: LineString
+    ) -> Dict[float, Tuple[float, float]]:
+        """
+        Compute a lookup table for the normals for each line segment in the line string.
+        This is done so that given an interpolated distance (between 0 and 1) on the
+        line string, we can quickly find the normal at that distance.
+        """
+        normals = {}
+        start_x, start_y = line_string[0][:2]
+        for end_x, end_y, *_ in line_string[1:]:
+            if (end_x, end_y) == line_string[-1][:2]:
+                distance = 1  # Make sure distance 1 ends at the last point
+            else:
+                distance = line_string.project_normalized(Point(end_x, end_y))
+            # Calculate the normal
+            dx = end_x - start_x
+            dy = end_y - start_y
+            length = sqrt(dx ** 2 + dy ** 2)
+            normal = -dy / length, dx / length
+            # Associate with the distance for fast lookup of the
+            # normal between the current start point and end point.
+            normals[distance] = normal
+            start_x, start_y = end_x, end_y
+        return normals
+
+    def _find_normal(
+        self, distance: float, normals: dict, opposite: bool = False
+    ) -> Tuple[float, float]:
+        """
+        Given an distance between 0 and 1 on the line string, find the normal
+        (or its opposite) from the provided dictionary.
+        """
+        distances = list(normals.keys())
+        distance_index = bisect_left(distances, distance)
+        normal_index = distances[distance_index]
+        x, y = normals[normal_index]
+        # If we are creating addresses for the right side of the street,
+        # we need the normal pointing in the opposite direction.
+        if opposite:
+            return -x, -y
+        return x, y
+
+    @lru_cache(maxsize=None)
+    def _create_municipality(self, municipality_id: int) -> Municipality:
+        """Create a new municipality if it does not exist already, and return it."""
+        municipality_fi, municipality_sv = MUNICIPALITIES[self.province][
+            municipality_id
+        ]
+        municipality, _ = Municipality.objects.get_or_create(id=municipality_fi.lower())
+        municipality.set_current_language("sv")
+        municipality.name = municipality_sv
+        municipality.set_current_language("fi")
+        municipality.name = municipality_fi
+        municipality.save()
+        return municipality
+
+    @lru_cache(maxsize=None)
+    def _create_street(
+        self, name_fi: str, name_sv: str, municipality: Municipality
+    ) -> Street:
+        """Create a new street if it does not exist already, and return it."""
+        street, _ = Street.objects.translated(name=name_fi).get_or_create(
+            municipality=municipality
+        )
+        street.set_current_language("sv")
+        street.name = name_sv
+        street.set_current_language("fi")
+        street.name = name_fi
+        street.save()
+        return street
+
+    def _has_required_fields(self, feature: Feature) -> bool:
+        """Check whether the feature contains street name and first/last numbers."""
+        street_keys = ["TIENIMI_SU", "TIENIMI_RU"]
+        number_keys = ["ENS_TALO_O", "ENS_TALO_V", "VIIM_TAL_O", "VIIM_TAL_V"]
+        has_street = any(feature[key].value for key in street_keys)
+        has_number = any(feature[key].value for key in number_keys)
+        return has_street and has_number

--- a/address/services/postal_code_import.py
+++ b/address/services/postal_code_import.py
@@ -4,33 +4,34 @@ from typing import Iterable
 from ..models import Address
 
 
-def import_postal_codes(features: Iterable[Feature]) -> int:
-    """
-    Go through the given postal code area features, find all addresses
-    that are within each area, and update the postal code of the address
-    accordingly.
-    """
-    total_addresses_updated = 0
+class PostalCodeImporter:
+    def import_postal_codes(self, features: Iterable[Feature]) -> int:
+        """
+        Go through the given postal code area features, find all addresses
+        that are within each area, and update the postal code of the address
+        accordingly.
+        """
+        total_addresses_updated = 0
 
-    # Clear existing postal codes and offices
-    Address.objects.filter(postal_code__isnull=False).update(
-        postal_code=None,
-        post_office=None,
-    )
-
-    # Update postal code for all addresses within each postal code area
-    for feature in features:
-        geometry = feature.geom.geos
-        postal_code = feature["posti_alue"].value
-        post_office = feature["nimi"].value
-        addresses = Address.objects.filter(
-            postal_code__isnull=True,
-            location__intersects=geometry,
+        # Clear existing postal codes and offices
+        Address.objects.filter(postal_code__isnull=False).update(
+            postal_code=None,
+            post_office=None,
         )
-        num_addresses_updated = addresses.update(
-            postal_code=postal_code,
-            post_office=post_office,
-        )
-        total_addresses_updated += num_addresses_updated
 
-    return total_addresses_updated
+        # Update postal code for all addresses within each postal code area
+        for feature in features:
+            geometry = feature.geom.geos
+            postal_code = feature["posti_alue"].value
+            post_office = feature["nimi"].value
+            addresses = Address.objects.filter(
+                postal_code__isnull=True,
+                location__intersects=geometry,
+            )
+            num_addresses_updated = addresses.update(
+                postal_code=postal_code,
+                post_office=post_office,
+            )
+            total_addresses_updated += num_addresses_updated
+
+        return total_addresses_updated

--- a/address/tests/test_address_import_service.py
+++ b/address/tests/test_address_import_service.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 from unittest.mock import MagicMock, Mock
 
 from ..models import Address, Municipality, Street
-from ..services.address_import import delete_address_data, import_addresses
+from ..services.address_import import AddressImporter
 from ..tests.factories import AddressFactory, MunicipalityFactory, StreetFactory
 
 TEST_FEATURE_FIELDS = {
@@ -26,13 +26,15 @@ TEST_GEOMETRY = LineString(
     srid=3067,
 )
 
+TEST_PROVINCE = "uusimaa"
+
 
 @mark.django_db(transaction=True)
 def test_delete_address_data_removes_municipalities_streets_and_addresses():
     MunicipalityFactory()
     StreetFactory()
     AddressFactory()
-    delete_address_data()
+    AddressImporter().delete_address_data()
     assert not Municipality.objects.exists()
     assert not Street.objects.exists()
     assert not Address.objects.exists()
@@ -47,7 +49,7 @@ def test_import_addresses_does_nothing_if_street_name_is_missing():
             "TIENIMI_RU": None,
         }
     )
-    import_addresses([feature])
+    AddressImporter(TEST_PROVINCE).import_addresses([feature])
     assert not Address.objects.exists()
 
 
@@ -62,14 +64,14 @@ def test_import_addresses_does_nothing_if_street_number_is_missing():
             "VIIM_TAL_V": None,
         }
     )
-    import_addresses([feature])
+    AddressImporter(TEST_PROVINCE).import_addresses([feature])
     assert not Address.objects.exists()
 
 
 @mark.django_db
 def test_import_addresses_creates_municipalities():
     feature = _mock_feature({**TEST_FEATURE_FIELDS, "KUNTAKOODI": 49})
-    import_addresses([feature])
+    AddressImporter(TEST_PROVINCE).import_addresses([feature])
     assert Municipality.objects.translated(name="Espoo").count() == 1
 
 
@@ -78,14 +80,14 @@ def test_import_addresses_creates_streets():
     feature = _mock_feature(
         {**TEST_FEATURE_FIELDS, "KUNTAKOODI": 149, "TIENIMI_SU": "CreationTest"}
     )
-    import_addresses([feature])
+    AddressImporter(TEST_PROVINCE).import_addresses([feature])
     assert Street.objects.translated(name="CreationTest").count() == 1
 
 
 @mark.django_db
 def test_import_addresses_creates_addresses():
     feature = _mock_feature({**TEST_FEATURE_FIELDS, "KUNTAKOODI": 186})
-    import_addresses([feature])
+    AddressImporter(TEST_PROVINCE).import_addresses([feature])
     street = Street.objects.get()
     expected_locations = [
         (24.94235, 60.22301),  # number 1, left side

--- a/address/tests/test_import_addresses_command.py
+++ b/address/tests/test_import_addresses_command.py
@@ -6,7 +6,7 @@ from address.models import Address, Municipality, Street
 
 @mark.django_db
 def test_import_addresses_creates_addresses_from_shapefile(shapefile):
-    call_command("import_addresses", [shapefile])
+    call_command("import_addresses", [shapefile], "uusimaa")
     assert Municipality.objects.count() == 1
     assert Street.objects.count() == 7
     assert Address.objects.count() == 37

--- a/address/tests/test_postal_code_import_service.py
+++ b/address/tests/test_postal_code_import_service.py
@@ -5,7 +5,7 @@ from pytest import mark
 from typing import Any, Dict
 from unittest.mock import MagicMock, Mock
 
-from ..services.postal_code_import import import_postal_codes
+from ..services.postal_code_import import PostalCodeImporter
 from ..tests.factories import AddressFactory
 
 TEST_GEOMETRY = Polygon.from_bbox([24.9427, 60.1665, 24.9430, 60.1667])
@@ -22,7 +22,7 @@ def test_import_postal_codes():
     postal_code = "00100"
     post_office = "Helsinki Keskusta - Etu-Töölö"
     feature = _mock_feature({"posti_alue": postal_code, "nimi": post_office})
-    import_postal_codes([feature])
+    PostalCodeImporter().import_postal_codes([feature])
     address.refresh_from_db()
     assert address.postal_code == postal_code
     assert address.post_office == post_office
@@ -37,7 +37,7 @@ def test_import_postal_codes_does_not_update_postal_code_if_outside(paavo_shapef
         post_office="",
     )
     feature = _mock_feature({"posti_alue": "00100", "nimi": "Helsinki"})
-    import_postal_codes([feature])
+    PostalCodeImporter().import_postal_codes([feature])
     address.refresh_from_db()
     assert not address.postal_code
     assert not address.post_office

--- a/scripts/import-digiroad-data.sh
+++ b/scripts/import-digiroad-data.sh
@@ -43,7 +43,7 @@ CONVERTED_DIR=$DATA_DIR/converted
 mkdir -p $DATA_DIR
 curl "$DATA_URL" -o $DATA_DIR/data.zip
 
-# # Extract the shapefiles from the archive
+# Extract the shapefiles from the archive
 rm -rf $EXTRACTED_DIR
 unzip $DATA_DIR/data.zip $SHAPEFILE_PATTERN -d $EXTRACTED_DIR
 

--- a/scripts/import-digiroad-data.sh
+++ b/scripts/import-digiroad-data.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -e
-available_provinces="'uusimaa' and 'varisinais-suomi'"
+available_provinces="'uusimaa' and 'varsinais-suomi'"
 
 if [ $# == 0 ]
 then

--- a/scripts/import-digiroad-data.sh
+++ b/scripts/import-digiroad-data.sh
@@ -1,12 +1,32 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
+available_provinces="'uusimaa' and 'varisinais-suomi'"
 
-# URL to a zip file containing .shp files
-DATA_URL=https://aineistot.vayla.fi/digiroad/latest/Maakuntajako_DIGIROAD_R_EUREF-FIN/UUSIMAA.zip
+if [ $# == 0 ]
+then
+    echo "No province argument supplied."    
+    echo "Available provinces are ${available_provinces}."
+    exit 0
+fi
 
+declare -A package_name
+package_name["varsinais-suomi"]="VARSINAIS-SUOMI.zip"
+package_name["uusimaa"]="UUSIMAA.zip"
+
+if [ ${package_name[$1]+_} ] 
+then 
+    echo "Importing Digiroad data for province $1."; 
+else 
+    echo "Province $1 not found, available provinces are ${available_provinces}."; 
+    exit 0
+fi
+
+echo ${package_name[$1]}
+
+DATA_URL="https://ava.vaylapilvi.fi/ava/Tiest%C3%B6tiedot/Digiroad/Digiroad-irrotusaineistot/latest/Maakuntajako_DIGIROAD_R_EUREF-FIN/${package_name[$1]}"
 # Directory where the data will be downloaded and extracted
-DATA_DIR=/tmp/digiroad
+DATA_DIR=/home/juuso/repos/geo-search/scripts/tmp/digiroad
 
 # Pattern identifying the shapefiles (.dbf, .prj, .shp, .shx).
 # The shapefiles are named DR_LINKKI.* or DR_LINKKI_K.*, depending
@@ -23,12 +43,12 @@ CONVERTED_DIR=$DATA_DIR/converted
 mkdir -p $DATA_DIR
 curl "$DATA_URL" -o $DATA_DIR/data.zip
 
-# Extract the shapefiles from the archive
+# # Extract the shapefiles from the archive
 rm -rf $EXTRACTED_DIR
 unzip $DATA_DIR/data.zip $SHAPEFILE_PATTERN -d $EXTRACTED_DIR
 
 # Remove the measurements (M coordinate) from each shapefile.
-# This is done because Django's OGRGeomType class doesn't support LineStringZM geometries:
+# This is done because Django's OGRGeomType classogr doesn't support LineStringZM geometries:
 # https://github.com/django/django/blob/ca9872905559026af82000e46cde6f7dedc897b6/django/contrib/gis/gdal/geomtype.py#L9
 rm -rf $CONVERTED_DIR
 mkdir -p $CONVERTED_DIR
@@ -42,4 +62,4 @@ done
 
 # Run the management command with all the shapefiles as arguments
 SCRIPT_DIR="$(cd "$(dirname "$0")"; pwd)"
-python "$SCRIPT_DIR/../manage.py" import_addresses $(find $CONVERTED_DIR -type f -name "DR_LINKK*.shp")
+python "$SCRIPT_DIR/../manage.py" import_addresses $(find $CONVERTED_DIR -type f -name "DR_LINKK*.shp") $1

--- a/scripts/import-digiroad-data.sh
+++ b/scripts/import-digiroad-data.sh
@@ -7,7 +7,7 @@ if [ $# == 0 ]
 then
     echo "No province argument supplied."    
     echo "Available provinces are ${available_provinces}."
-    exit 0
+    exit p0
 fi
 
 declare -A package_name
@@ -26,7 +26,7 @@ echo ${package_name[$1]}
 
 DATA_URL="https://ava.vaylapilvi.fi/ava/Tiest%C3%B6tiedot/Digiroad/Digiroad-irrotusaineistot/latest/Maakuntajako_DIGIROAD_R_EUREF-FIN/${package_name[$1]}"
 # Directory where the data will be downloaded and extracted
-DATA_DIR=/home/juuso/repos/geo-search/scripts/tmp/digiroad
+DATA_DIR=/tmp/digiroad
 
 # Pattern identifying the shapefiles (.dbf, .prj, .shp, .shx).
 # The shapefiles are named DR_LINKKI.* or DR_LINKKI_K.*, depending

--- a/scripts/import-digiroad-data.sh
+++ b/scripts/import-digiroad-data.sh
@@ -7,7 +7,7 @@ if [ $# == 0 ]
 then
     echo "No province argument supplied."    
     echo "Available provinces are ${available_provinces}."
-    exit p0
+    exit 0
 fi
 
 declare -A package_name

--- a/scripts/import-paavo-data.sh
+++ b/scripts/import-paavo-data.sh
@@ -26,7 +26,7 @@ fi
 # URL to Paavo WFS service
 DATA_URL="http://geo.stat.fi/geoserver/wfs?SERVICE=wfs&version=1.0.0&request=GetFeature&srsName=EPSG:3067&outputFormat=SHAPE-ZIP&typeNames=pno_meri_2021&bbox=${bbox[$1]}"
 
-DATA_DIR=/home/juuso/repos/geo-search/scripts/tmp/paavo
+DATA_DIR=/tmp/paavo
 
 # The shapefiles will be extracted to this directory
 EXTRACTED_DIR=$DATA_DIR/extracted

--- a/scripts/import-paavo-data.sh
+++ b/scripts/import-paavo-data.sh
@@ -1,12 +1,32 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
-# URL to Paavo WFS service
-DATA_URL="http://geo.stat.fi/geoserver/wfs?SERVICE=wfs&version=1.0.0&request=GetFeature&srsName=EPSG:3067&outputFormat=SHAPE-ZIP&typeNames=pno_meri_2021&bbox=267392.57814054575,6636189.158504381,476288.57814054575,6747293.158504381"
+available_provinces="'uusimaa' and 'varisinais-suomi'"
 
-# Directory where the data will be downloaded and extracted
-DATA_DIR=/tmp/paavo
+if [ $# == 0 ]
+then
+    echo "No province argument supplied."    
+    echo "Available provinces are ${available_provinces}."
+    exit 0
+fi
+
+declare -A bbox
+bbox["varsinais-suomi"]="125189.83,6611707.59,334187.32,6781558.98"
+bbox["uusimaa"]="267392.57814054575,6636189.158504381,476288.57814054575,6747293.158504381"
+
+if [ ${bbox[$1]+_} ] 
+then 
+    echo "Importing Paavo data for province $1."; 
+else 
+    echo "Province $1 not found, available provinces are ${available_provinces}."; 
+    exit 0
+fi
+
+# URL to Paavo WFS service
+DATA_URL="http://geo.stat.fi/geoserver/wfs?SERVICE=wfs&version=1.0.0&request=GetFeature&srsName=EPSG:3067&outputFormat=SHAPE-ZIP&typeNames=pno_meri_2021&bbox=${bbox[$1]}"
+
+DATA_DIR=/home/juuso/repos/geo-search/scripts/tmp/paavo
 
 # The shapefiles will be extracted to this directory
 EXTRACTED_DIR=$DATA_DIR/extracted

--- a/scripts/import-paavo-data.sh
+++ b/scripts/import-paavo-data.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-available_provinces="'uusimaa' and 'varisinais-suomi'"
+available_provinces="'uusimaa' and 'varsinais-suomi'"
 
 if [ $# == 0 ]
 then


### PR DESCRIPTION
# Support for multiple provinces and added province Southwest Finland

### Breakdown 
#### Scripts
1. scripts/import-digiroad-data.sh
    * Now imports addresses by the the province given as argument.  
2. scripts/import-paavo-data.sh
    * Now imports postal codes and offices by the province given as argument.
#### Importers
1. address/services/address_import.py
    * Moved import functionality into a class. The constructor of the class takes the province as input, this variable is used when deleting or importing by province. Added province names as keys to the MUNICIPALITIES dict. Also added the municipalities of Southwest Finland. 
4. address/services/postal_code_import.py
    * Moved functionality into a class to make importer uniform with the address importer.
    
#### Commands
1. address/management/commands/import_addresses.py
    * Now uses the instance with the province argument of the AddressImporter class to delete and import addresses.
5. address/management/commands/import_postal_codes.py
    * Now uses the instance of the PostalCode importer class to import. 

#### Tests
1. address/tests/test_address_import_service.py
    * Changed to use instances of AddressImporter class with "uusima" as province.  
2. address/tests/test_import_addresses_command.py
    * Added the province to the call_command.
4. address/tests/test_postal_code_import_service.py
    * Changed to use instances of PostalCodeImporter.