### PR TITLE
Use Ubuntu 22.04 base image with python3-gdal -package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 # Fixes git vulnerability issue in openshift
 COPY .gitconfig .
@@ -8,7 +8,7 @@ COPY .gitconfig /etc/gitconfig
 WORKDIR /app
 
 RUN apt-get -o Acquire::Check-Valid-Until=false -o Acquire::Check-Date=false update && \
-    TZ="Europe/Helsinki" DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https python3-pip gdal-bin uwsgi uwsgi-plugin-python3 libgdal26 git-core postgresql-client netcat gettext libpq-dev unzip && \
+    TZ="Europe/Helsinki" DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https python3-pip gdal-bin python3-gdal uwsgi uwsgi-plugin-python3 git-core postgresql-client netcat gettext libpq-dev unzip && \
     ln -s /usr/bin/pip3 /usr/local/bin/pip && \
     ln -s /usr/bin/python3 /usr/local/bin/python
 


### PR DESCRIPTION
Use Ubuntu 22.04 base image with `python3-gdal`-package to support latest Django v.5.0.6.

[Refs](https://trello.com/c/XDXyZH1Z/1580-paikkatietohaun-kontituksen-p%C3%A4ivitys)