### PR TITLE
Move Api-Key to custom header

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ once, so make sure you copy it.
 
 ### Making authorized requests
 
-Clients must pass their API key via the `Authorization` header.
+Clients must pass their API key via header.
 It must be formatted as follows:
 
-    Authorization: Api-Key <API_KEY>
+    Api-Key: <API_KEY>
 
 Where `<API_KEY>` refers to the full generated API key.
 

--- a/address/tests/conftest.py
+++ b/address/tests/conftest.py
@@ -11,7 +11,7 @@ from rest_framework_api_key.models import APIKey
 @fixture
 def api_client() -> APIClient:
     api_key = APIKey.objects.create_key(name="test")[-1]
-    return APIClient(HTTP_AUTHORIZATION=f"Api-Key {api_key}")
+    return APIClient(HTTP_API_KEY=api_key)
 
 
 @fixture

--- a/geo_search/settings.py
+++ b/geo_search/settings.py
@@ -153,8 +153,24 @@ SPECTACULAR_SETTINGS = {
     "DESCRIPTION": "Service for searching geospatial information.",
     "SERVE_INCLUDE_SCHEMA": False,
     "VERSION": None,
+    "AUTHENTICATION_WHITELIST": [],
+    "APPEND_COMPONENTS": {
+        "securitySchemes": {
+            "ApiKeyAuth": {
+                "type": "apiKey",
+                "in": "header",
+                "name": "Api-Key",
+            }
+        }
+    },
+    "SECURITY": [
+        {
+            "ApiKeyAuth": [],
+        }
+    ],
 }
 
 REQUIRE_AUTHORIZATION = env.bool("REQUIRE_AUTHORIZATION")
+API_KEY_CUSTOM_HEADER = "HTTP_API_KEY"
 
 USE_X_FORWARDED_HOST = True

--- a/geo_search/tests/test_permissions.py
+++ b/geo_search/tests/test_permissions.py
@@ -22,7 +22,7 @@ def test_anonymous_client_can_access_api_if_authorization_is_not_required():
 @mark.usefixtures("authorization_required")
 def test_anonymous_client_can_access_api_with_valid_api_key():
     valid_api_key = APIKey.objects.create_key(name="test")[-1]
-    api_client = APIClient(HTTP_AUTHORIZATION=f"Api-Key {valid_api_key}")
+    api_client = APIClient(HTTP_API_KEY=valid_api_key)
     response = api_client.get("/v1/")
     assert response.status_code == 200
 
@@ -31,7 +31,7 @@ def test_anonymous_client_can_access_api_with_valid_api_key():
 @mark.usefixtures("authorization_required")
 def test_anonymous_client_cannot_access_api_with_revoked_api_key():
     revoked_api_key = APIKey.objects.create_key(name="test", revoked=True)[-1]
-    api_client = APIClient(HTTP_AUTHORIZATION=f"Api-Key {revoked_api_key}")
+    api_client = APIClient(HTTP_API_KEY=revoked_api_key)
     response = api_client.get("/v1/")
     assert response.status_code == 403
 


### PR DESCRIPTION
Move Api-Key to custom header and add it to the OpenAPI documentation.

<img width="722" alt="openapiauth" src="https://github.com/user-attachments/assets/a05e3614-8d7f-4340-a34a-d7607ca39117">

[Refs](https://trello.com/c/ubNJgFTG/1595-paikkatietohaku-bearer-autentikaation-k%C3%A4ytt%C3%B6%C3%B6notto)