### PR TITLE
ci(dependabot): remove unnecessary cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    cooldown:
-      default-days: 7
     commit-message:
       prefix: "deps"
     # Disable version updates and only allow security updates


### PR DESCRIPTION
Cooldown in unnecessary, since it does not concern Dependabot security updates.

Refs: [RATYK-185](https://helsinkisolutionoffice.atlassian.net/browse/RATYK-185)

[RATYK-185]: https://helsinkisolutionoffice.atlassian.net/browse/RATYK-185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management automation configuration to adjust update scheduling and limit certain types of automated pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->